### PR TITLE
Fix/twitter card

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -5,13 +5,13 @@
  * See: https://www.gatsbyjs.org/docs/use-static-query/
  */
 
-import React from "react"
-import PropTypes from "prop-types"
-import Helmet from "react-helmet"
-import { useStaticQuery, graphql } from "gatsby"
 import getSharingImage from '@jlengstorf/get-share-image'
+import { graphql, useStaticQuery } from "gatsby"
+import PropTypes from "prop-types"
+import React from "react"
+import Helmet from "react-helmet"
 
-function SEO({canonical, description, lang, meta, keywords, title }) {
+function SEO({canonical, description, lang, meta, keywords, title, tagline }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -29,15 +29,15 @@ function SEO({canonical, description, lang, meta, keywords, title }) {
   const metaDescription = description || site.siteMetadata.description
 
     const socialImage = getSharingImage({
-        title: 'How to be a x developer',
-        tagline: 'Learn all the tips from this one post',
+        title: title,
+        tagline: tagline ? tagline : '',
         cloudName: 'rajatnegi',
         imagePublicID: 'blog-img.png',
         titleFont: 'Roboto',
         titleExtraConfig: '_bold',
         taglineFont: 'Roboto',
+        textColor: 'ffffff',
       })
-    // const image = isBlogPost ? socialImage : seo.image
 
   return (
     <Helmet
@@ -86,7 +86,7 @@ function SEO({canonical, description, lang, meta, keywords, title }) {
         },
         {
           name: `twitter:image`,
-          content: {socialImage},       
+          content: socialImage,
         }
       ]
         .concat(

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,7 @@ class IndexPage extends React.Component {
         <SEO
           title="Home"
           keywords={[`blog`, `gatsby`, `javascript`, `react`]}
+          tagline="Personal Blog Rajat Negi"
         />
         <img style={{ margin: 0 }} src="./scene.gif" alt="Gatsby Scene" />
         <h1>


### PR DESCRIPTION
**Summary**
- Fixes issue with Twitter card image URL not being added correctly in meta
- Adds supports for `tagline` prop on the SEO component

**Description**

So, what was happening in the `socialImage` variable was being wrapped inside a `{}` — which turned it into an Object, where-as, it's meant to be a string. Removing the `{}` outputs the variable as a string, which should work fine.